### PR TITLE
Enhance install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,15 @@ Hosts with Screen Sharing enabled will **be automatically discovered** and liste
 
 ![Screenshot of "Screen Sharing for Alfred"](screenshot.png)
 
-[Download](Screen%20Sharing.alfredworkflow?raw=true)
+## Installation
+
+First, install `dnssd` to the default OS X ruby gemset.
+
+```bash
+# If using rbenv, first run `rbenv global system`
+# If using RVM, first run `rvm use system`
+# Otherwise, just run:
+$ sudo gem install dnssd
+```
+
+Afterwards, [download](Screen%20Sharing.alfredworkflow?raw=true) and install the Alfred workflow.


### PR DESCRIPTION
Specifically to document the dnssd gem dependency
